### PR TITLE
[Refactor]: Simplify `#fadeInThen:`s Block Passing

### DIFF
--- a/repository/Animations.package/Morph.extension/instance/fadeInThen..st
+++ b/repository/Animations.package/Morph.extension/instance/fadeInThen..st
@@ -5,6 +5,6 @@ fadeInThen: aBlock
 	(AnimAlphaBlendAnimation
 		fadeInOn: self
 		duration: 200)
-		finishBlock: [aBlock value];
+		finishBlock: aBlock;
 		register;
 		start: #deleteWhenFinished.


### PR DESCRIPTION
I was intrigued by a Squeak forum post and clicked through to review the code on GH. I happened to notice this.